### PR TITLE
TargetCamera: Fix unable to paint between wc sessions without restarting

### DIFF
--- a/Plugins/TargetCamera.xml
+++ b/Plugins/TargetCamera.xml
@@ -9,5 +9,5 @@
 FOV is automatically adjusted to enclose the target. Scale and position can both be configured, as well as an optional minimum distance to cease drawing the camera.
   
 To use, simply select a target using either targeting methods.</Description>
-  <Commit>d7dba8f43407daf501e19632c29370239e5092c6</Commit>
+  <Commit>2676d9b6b36dffe33478fb200b82ca2322f28fc2</Commit>
 </PluginData>


### PR DESCRIPTION
This was because the weaponcore interop wasn't being invalidated on world unload