### PR TITLE
Multigrid Projector 0.8.2

### DIFF
--- a/Plugins/MultigridProjector.xml
+++ b/Plugins/MultigridProjector.xml
@@ -4,12 +4,6 @@
    
   <FriendlyName>Multigrid Projector</FriendlyName>
   <Author>Viktor</Author>
-  <Commit>7f3479bb04f6134f440414c2bd3a713b87a906dc</Commit>
-  <SourceDirectories>
-    <Directory>MultigridProjector</Directory>
-    <Directory>MultigridProjectorApi</Directory>
-    <Directory>MultigridProjectorClient</Directory>
-  </SourceDirectories>
   <Tooltip>Allows loading blueprints of multiple sub-grids into projectors and welding them.</Tooltip>
   <Description>This plugin allows to load blueprints of multiple sub-grids into projectors and welding the blocks. Head/base blocks are added automatically as needed to connect subgrids.
 
@@ -25,10 +19,22 @@ https://www.paypal.com/paypalme/vferenczi/
 Thank you!
   </Description>
 
+  <SourceDirectories>
+    <Directory>MultigridProjector</Directory>
+    <Directory>MultigridProjectorApi</Directory>
+    <Directory>MultigridProjectorClient</Directory>
+  </SourceDirectories>
+
+  <Commit>48b19a97164422df21bb35eea959911ceebbfddb</Commit>
+
   <AlternateVersions>
     <Version>
-      <Name>For SE 1.205.026</Name>
+      <Name>MGP 0.8.1 for SE 1.205.032</Name>
       <Commit>8ea45826a5bb2b57dcd05aff4d80905db8052ae1</Commit>
+    </Version>
+    <Version>
+      <Name>MGP 0.8.0 for SE 1.205.026</Name>
+      <Commit>7f3479bb04f6134f440414c2bd3a713b87a906dc</Commit>
     </Version>
     <Version>
       <Name>For SE 1.204.018</Name>


### PR DESCRIPTION
- Voxel collisions are now considered in block highlighting, they show up in cyan color. (client only)
- Block references (toolbar slots, turret rotors/hinges, etc.) are now properly restored on building blocks from projection. (client and server)
- Improved client only build in multiplayer if there is no MGP plugin on server side, including restoring block references. (client only build)
- Custom button names on button panels are now properly restored. Ported this fix from the Sections plugin.
- The "Fix Toolbars" projector action now restores all block references, not only toolbar slots.
- Minor stability fixes and code cleanup.

Since this plugin is pretty much complete, I'm planning on releasing MGP 1.0.0 in a few months.

The MGP API Agent code (for PB, Mod and other plugins) verifies the major version number of the plugin and refuses to work it is not zero. With this MGP release I've removed this check, so it will be possible to change the major version number to 1.

The agent code was copied into other scripts and mods to provide access to projection data. If you copied the agent into your script or mod, then please update the code from the GitHub repository (https://github.com/viktor-ferenczi/multigrid-projector/) according to your usage:

- **Script**: Copy the code from the `MGP API Agent` region of `IngameApiTest/Script/Script.cs`
- **Mod**: Copy the source files from the `MultigridProjectorApi/Api` directory
- **Plugin**: Same source files as with mods, but you get access to the provider with reflection

There has been no change to the actual API, so all your existing code will remain compatible.

Big thanks to @spacegt for contributing to the development of the above features.