### PR TITLE
Second Screen Display 0.5.0

### DIFF
--- a/Plugins/SecondScreenDisplay.xml
+++ b/Plugins/SecondScreenDisplay.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <!-- Place your github repository name here. One repository can only store one plugin. This one is from https://github.com/austinvaness/ToolSwitcherPlugin -->
+  <Id>Brillcrafter/Second-Screen-Display</Id>
+  
+  <!-- The name of your plugin that will appear in the list. -->
+  <FriendlyName>Second Screen Display</FriendlyName>
+  
+  <!-- The author name that you want to appear in the list. -->
+  <Author>Brillcrafter</Author>
+  
+  <!-- Optional tag that adds a tooltip to the plugin in-game. -->
+  <Tooltip>Allows you to display HudLcd readouts on a separate window</Tooltip>
+
+  <!-- Optional tag that adds a plugin description. If omitted, this will be the same as the Tooltip. 1000 characters max. -->
+  <Description>This plugin allows you to move all the HudLcd items into a separate window that you can do whatever with.
+      To Activate the screen, use the command "/ssd open" and you can close it whenever. </Description>
+  
+  <!-- The commit id. You can find this in the commits list: https://github.com/austinvaness/ToolSwitcherPlugin/commits/main -->
+  <Commit>UPDATE THIS!!!</Commit>
+  
+  <!-- Optional list of directories to take the cs files from. Use this if your repository has more than one project in it. (It is not needed for Tool Switcher)
+  <SourceDirectories>
+    <Directory>Folder/Directory1</Directory>
+    <Directory>Directory 2</Directory>
+  </SourceDirectories> -->
+  
+  <!-- Optional tag that specifies whether the plugin is hidden. Hidden plugins only appear when they are enabled or searched for in the search box.
+  <Hidden>true</Hidden> -->
+
+  <!-- Optional list of alternate versions of the plugin
+  <AlternateVersions>
+    <Version>
+      <Name>Version Name</Name>
+      <Commit>Commit ID</Commit>
+    </Version>
+  </AlternateVersions> -->
+
+    <!-- To specify asset files to be copied onto disk, use the AssetFolder tag.-->
+    <AssetFolder>SecondScreenDisplay/resources/</AssetFolder> -->
+</PluginData>

--- a/Plugins/SecondScreenDisplay.xml
+++ b/Plugins/SecondScreenDisplay.xml
@@ -17,25 +17,8 @@
       To Activate the screen, use the command "/ssd open" and you can close it whenever. </Description>
   
   <!-- The commit id. You can find this in the commits list: https://github.com/austinvaness/ToolSwitcherPlugin/commits/main -->
-  <Commit>UPDATE THIS!!!</Commit>
+  <Commit>ef6a552353b40bd159bace9b596ac5a72cbec0bd</Commit>
   
-  <!-- Optional list of directories to take the cs files from. Use this if your repository has more than one project in it. (It is not needed for Tool Switcher)
-  <SourceDirectories>
-    <Directory>Folder/Directory1</Directory>
-    <Directory>Directory 2</Directory>
-  </SourceDirectories> -->
-  
-  <!-- Optional tag that specifies whether the plugin is hidden. Hidden plugins only appear when they are enabled or searched for in the search box.
-  <Hidden>true</Hidden> -->
-
-  <!-- Optional list of alternate versions of the plugin
-  <AlternateVersions>
-    <Version>
-      <Name>Version Name</Name>
-      <Commit>Commit ID</Commit>
-    </Version>
-  </AlternateVersions> -->
-
-    <!-- To specify asset files to be copied onto disk, use the AssetFolder tag.-->
-    <AssetFolder>SecondScreenDisplay/resources/</AssetFolder> -->
+  <!-- To specify asset files to be copied onto disk, use the AssetFolder tag.-->
+  <AssetFolder>SecondScreenDisplay/resources/</AssetFolder> -->
 </PluginData>


### PR DESCRIPTION
This plugin allows you to move any hud lcd displays into a new window, to allow you to move them to another display and stop them cluttering up your HUD