### PR TITLE
Add Layer Projector plugin

### DIFF
--- a/Plugins/LayerProjector.xml
+++ b/Plugins/LayerProjector.xml
@@ -16,5 +16,5 @@
   <Description>This plugin adds layer-by-layer projection mode to projectors, similar to 3D printing. Display and build one layer at a time with customizable axis selection (X, Y, or Z). Features include: dynamic layer bounds calculation, build restriction to active layer only, navigation buttons and slider, detailed statistics panel showing block counts and types, and automatic state persistence between sessions. Perfect for precise construction and understanding complex blueprints.</Description>
   
   <!-- Commit ID from: https://github.com/Shaion/LayerProjectorPlugin/commits/main -->
-  <Commit>d5cf27b5e6f7a9c7a57e4e7f7c5f1f8c3c8e7a1d</Commit>
+  <Commit>fdbd6e1c8e0c3f3e1f2f4f6f8f0f2f4f6f8f0f2</Commit>
 </PluginData>


### PR DESCRIPTION
     Layer-by-layer projection mode for projectors, similar to 3D printing.
     
     Features:
     - Display one layer at a time
     - Customizable axis (X, Y, Z)
     - Build restriction to active layer
     - Detailed statistics panel
     
     Repository: https://github.com/Shaion/LayerProjectorPlugin
     Author: Shaion