### PR TITLE
Add Smooth Frames plugin

### DIFF
--- a/Plugins/SmoothFrames.xml
+++ b/Plugins/SmoothFrames.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+	<Id>WhiteFang34/SmoothFrames</Id>
+	<FriendlyName>Smooth Frames</FriendlyName>
+	<Author>WhiteFang</Author>
+	<Tooltip>Smooth motion at any refresh rate.</Tooltip>
+	<Description>Space Engineers updates its sim at 60 Hz, so motion looks like 60 FPS even on a 144 Hz or 240 Hz monitor — each render frame is a copy of the last sim tick. Smooth Frames interpolates the camera and nearby entities between sim ticks, so each render frame shows a distinct moment of motion. The engine's 120 FPS cap is also lifted, for users above that.
+
+Toggle with Ctrl+F11. Configure the frame-rate cap in the plugin's settings cog (default: your monitor's refresh).</Description>
+	<SourceDirectories>
+		<Directory>Plugin</Directory>
+	</SourceDirectories>
+	<Commit>34d8865565182d27dd46cc093b068bc84b5be290</Commit>
+</PluginData>


### PR DESCRIPTION
Smooth Frames interpolates the camera and nearby entities between sim ticks, so each render frame shows a distinct moment of motion on high-refresh-rate monitors. The engine's 120 FPS cap is also lifted.

## Controls
- **Ctrl+F11** toggles interpolation on/off.
- Frame-rate cap slider in the plugin settings cog (default: monitor refresh).

## Compatibility
Client-side only — no network state, safe on any server without server-side install, can't cause desync.