### PR TITLE
Add Shipyard

### DIFF
--- a/Plugins/Shipyard.xml
+++ b/Plugins/Shipyard.xml
@@ -15,7 +15,7 @@ Features: shared ship library browsing; check-out locks; publish/update as PRs w
 
 MIT licensed. Source: https://github.com/arsnekfcn/Shipyard</Description>
 
-  <Commit>cbd717149f08b930ead3d5150647c85736f3fd42</Commit>
+  <Commit>76a499ad0f402278b3bf58e0f0c760bc9b64a463</Commit>
 
   <!-- Windows / .NET Framework only: uses DPAPI (token encryption) and System.Drawing (thumbnail
        normalization), and vendors net48 builds of Octokit / LibGit2Sharp. -->

--- a/Plugins/Shipyard.xml
+++ b/Plugins/Shipyard.xml
@@ -15,14 +15,14 @@ Features: shared ship library browsing; check-out locks; publish/update as PRs w
 
 MIT licensed. Source: https://github.com/arsnekfcn/Shipyard</Description>
 
-  <Commit>76a499ad0f402278b3bf58e0f0c760bc9b64a463</Commit>
+  <Commit>988923faa1e7cc765858c8a8de9ebbfbd5fca348</Commit>
 
   <!-- Windows / .NET Framework only: uses DPAPI (token encryption) and System.Drawing (thumbnail
-       normalization), and vendors net48 builds of Octokit / LibGit2Sharp. -->
+       normalization). -->
   <Runtimes>NETFramework</Runtimes>
 
-  <!-- Pulsar compiles from source and resolves third-party deps from NuGet (our csproj's vendored/
-       embedded copies are for the local/manual build only). Pinned to the versions we developed against. -->
+  <!-- Pulsar compiles from source and resolves third-party deps from NuGet (the csproj additionally
+       embeds them for the local/manual single-file build only). Pinned to the versions we developed against. -->
   <NuGetReferences>
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />

--- a/Plugins/Shipyard.xml
+++ b/Plugins/Shipyard.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+
+  <Id>arsnekfcn/Shipyard</Id>
+  <FriendlyName>Shipyard</FriendlyName>
+  <Author>arsnek</Author>
+
+  <Tooltip>In-game, GitHub-backed blueprint version control.</Tooltip>
+
+  <Description>In-game blueprint version control for Space Engineers, backed by GitHub.
+
+Sign in with GitHub from inside the game, then publish, check out, review, and diff ships as pull requests — no website needed. Shipyard can even create a private repo for you. Or work fully offline with a local git repo (no account or network).
+
+Features: shared ship library browsing; check-out locks; publish/update as PRs with in-game review, approve, and merge; visual wireframe diffs of what changed between versions; one-click Steam Workshop publishing; per-user GitHub token stored locally. Blueprints are scrubbed of owner/SteamID/GPS on commit.
+
+MIT licensed. Source: https://github.com/arsnekfcn/Shipyard</Description>
+
+  <Commit>cbd717149f08b930ead3d5150647c85736f3fd42</Commit>
+
+  <!-- Windows / .NET Framework only: uses DPAPI (token encryption) and System.Drawing (thumbnail
+       normalization), and vendors net48 builds of Octokit / LibGit2Sharp. -->
+  <Runtimes>NETFramework</Runtimes>
+
+  <!-- Pulsar compiles from source and resolves third-party deps from NuGet (our csproj's vendored/
+       embedded copies are for the local/manual build only). Pinned to the versions we developed against. -->
+  <NuGetReferences>
+    <PackageReference Include="Octokit" Version="13.0.1" />
+    <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
+  </NuGetReferences>
+
+</PluginData>

--- a/Plugins/Shipyard.xml
+++ b/Plugins/Shipyard.xml
@@ -15,7 +15,7 @@ Features: shared ship library browsing; check-out locks; publish/update as PRs w
 
 MIT licensed. Source: https://github.com/arsnekfcn/Shipyard</Description>
 
-  <Commit>988923faa1e7cc765858c8a8de9ebbfbd5fca348</Commit>
+  <Commit>15281022773917f6bd8831f55715e8667138a8c3</Commit>
 
   <!-- Windows / .NET Framework only: uses DPAPI (token encryption) and System.Drawing (thumbnail
        normalization). -->

--- a/Plugins/Shipyard.xml
+++ b/Plugins/Shipyard.xml
@@ -21,8 +21,11 @@ MIT licensed. Source: https://github.com/arsnekfcn/Shipyard</Description>
        normalization). -->
   <Runtimes>NETFramework</Runtimes>
 
-  <!-- Pulsar compiles from source and resolves third-party deps from NuGet (the csproj additionally
-       embeds them for the local/manual single-file build only). Pinned to the versions we developed against. -->
+  <!-- Logo crest etc. Pulsar exposes this repo folder and calls Plugin.LoadAssets(path) with it. -->
+  <AssetFolder>assets</AssetFolder>
+
+  <!-- Pulsar compiles from source and restores these from NuGet (the local/manual build ships them as
+       separate files alongside the DLL). Pinned to the versions we developed against. -->
   <NuGetReferences>
     <PackageReference Include="Octokit" Version="13.0.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />

--- a/Plugins/Shipyard.xml
+++ b/Plugins/Shipyard.xml
@@ -15,7 +15,7 @@ Features: shared ship library browsing; check-out locks; publish/update as PRs w
 
 MIT licensed. Source: https://github.com/arsnekfcn/Shipyard</Description>
 
-  <Commit>3d1574c35fee37a3da895162199d81783975f134</Commit>
+  <Commit>1d2b9a1337d621adaec18a99f412285ffe1651cb</Commit>
 
   <!-- Windows / .NET Framework only: uses DPAPI (token encryption) and System.Drawing (thumbnail
        normalization). -->

--- a/Plugins/Shipyard.xml
+++ b/Plugins/Shipyard.xml
@@ -15,7 +15,7 @@ Features: shared ship library browsing; check-out locks; publish/update as PRs w
 
 MIT licensed. Source: https://github.com/arsnekfcn/Shipyard</Description>
 
-  <Commit>15281022773917f6bd8831f55715e8667138a8c3</Commit>
+  <Commit>087194fc27c4cc21b059d89674d98a4bae470137</Commit>
 
   <!-- Windows / .NET Framework only: uses DPAPI (token encryption) and System.Drawing (thumbnail
        normalization). -->

--- a/Plugins/Shipyard.xml
+++ b/Plugins/Shipyard.xml
@@ -15,7 +15,7 @@ Features: shared ship library browsing; check-out locks; publish/update as PRs w
 
 MIT licensed. Source: https://github.com/arsnekfcn/Shipyard</Description>
 
-  <Commit>087194fc27c4cc21b059d89674d98a4bae470137</Commit>
+  <Commit>3d1574c35fee37a3da895162199d81783975f134</Commit>
 
   <!-- Windows / .NET Framework only: uses DPAPI (token encryption) and System.Drawing (thumbnail
        normalization). -->


### PR DESCRIPTION
Adds **Shipyard**. In-game, GitHub-backed blueprint version control for Space Engineers

- **Repo:** https://github.com/arsnekfcn/Shipyard (public, MIT)
- **Commit:** `76a499ad0f402278b3bf58e0f0c760bc9b64a463`
- **Runtime:** NETFramework (net48) — uses DPAPI for local token storage and
  System.Drawing for thumbnail normalization
- **NuGet deps:** Octokit 13.0.1 (GitHub API), LibGit2Sharp 0.30.0 (offline/local-git mode)

**What it does:** sign in with GitHub from inside the game, then publish, check out,
review, and diff ships as pull requests. Alternatively, work fully offline with a local
git repo. Optional one-click Steam Workshop publishing.

**Trust notes:** each user authenticates to their own GitHub account; the token is stored
locally (DPAPI), with no shared backend. Committed blueprints are scrubbed of
owner / SteamID / GPS. Workshop uploads are unlisted by default. See
[SECURITY.md](https://github.com/arsnekfcn/Shipyard/blob/main/SECURITY.md) in the repo for more details.
