### PR TITLE
Update SeMcp plugin metadata and dependencies

### DIFF
--- a/Plugins/SeMcp.xml
+++ b/Plugins/SeMcp.xml
@@ -2,17 +2,22 @@
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
 
     <Id>566F463B-D7E8-4FE5-9AD2-314BD85425CD</Id>
+
     <RepoId>lolifamily/se-mcp</RepoId>
+
     <FriendlyName>SeMcp</FriendlyName>
+
     <Author>lolifamily</Author>
+
     <Tooltip>MCP server for LLM-driven code execution inside Space Engineers</Tooltip>
+
     <Description>*** WARNING — REMOTE CODE EXECUTION ***
-The bearer token = root password. Any client with it can run arbitrary C# on your machine (file I/O, processes, native [DllImport]). Never share or screenshot it; never port-forward the listener. Binds 127.0.0.1 only; multiplayer adds an Admin/Owner check, but single player needs only the token.
+The bearer token = root password. Any client with it can run arbitrary C# on your machine (file I/O, processes, native [DllImport]). Never share or screenshot it; never port-forward the listener. Binds 127.0.0.1 only; multiplayer requires Admin or Owner promote level.
 
 Turns your Space Engineers game into an MCP (Model Context Protocol) server. An LLM like Claude can connect over HTTP and execute C# directly in the running game engine with full .NET and game API access.
 
 Features:
-- REPL-style: no boilerplate, Roslyn 4.12, [DllImport] supported
+- REPL-style: no boilerplate, Roslyn 5.0, [DllImport] supported
 - All loaded assemblies referenced (.NET + game + plugins)
 - Multi-frame coroutines + parallel script execution
 - Console.WriteLine() piped back to the LLM
@@ -24,12 +29,13 @@ Transport: MCP Streamable HTTP (not SSE). POST JSON-RPC to http://localhost:9876
 
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
+        <Directory>Shared</Directory>
     </SourceDirectories>
 
     <NuGetReferences>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
     </NuGetReferences>
 
-    <Commit>a2ec26ad79d0115f324d69e542bcda6a472a310f</Commit>
+    <Commit>26574d49d3e507886b7aaf235dda8a4b254cd691</Commit>
 
 </PluginData>


### PR DESCRIPTION
Updated the plugin description and features, changed the Roslyn version to 5.0, and updated the commit hash.