### PR TITLE
Add HUD Hooks

### DIFF
--- a/Plugins/HudHooks.xml
+++ b/Plugins/HudHooks.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>AF7C26DB-2142-46C3-AC11-2DC7771A4F39</Id>
+  <RepoId>VanirDev/se-plugin-hudhooks</RepoId>
+  <FriendlyName>HUD Hooks</FriendlyName>
+  <Author>VanirDev</Author>
+  <Tooltip>Lets mods hide the crosshair and hold ESC while their own screen is open.</Tooltip>
+  <Description>Gives mods control over parts of the HUD that the Mod API does not expose, over a mod message channel.
+
+    Hooks available so far:
+    - Hide the in-world crosshair.
+    - Intercept ESC, so the pause menu does not open on top of the mod's screen.
+
+    Tokens are tracked per screen, so several mods can hold hooks at the same time without interfering with each other, and the HUD returns to normal once the last token is released. Pressing ESC twice within half a second always opens the pause menu, so a mod that fails to release its token cannot lock you out.
+
+    The plugin does nothing on its own. Install it when a mod you use asks for it. Mods keep working without it, just without the hooks.
+  </Description>
+  <SourceDirectories>
+    <Directory>HudHooks</Directory>
+  </SourceDirectories>
+  <Commit>8d912fe20ccecf3105ca70fac591763330bd75da</Commit>
+</PluginData>

--- a/Plugins/HudHooks.xml
+++ b/Plugins/HudHooks.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
   <Id>AF7C26DB-2142-46C3-AC11-2DC7771A4F39</Id>
   <RepoId>VanirDev/se-plugin-hudhooks</RepoId>


### PR DESCRIPTION
Adds **HUD Hooks**, a small API plugin that lets mods take over parts of the HUD the Mod API does not expose.

- **Repo:** https://github.com/VanirDev/se-plugin-hudhooks (public, MIT)
- **Commit:** `8d912fe20ccecf3105ca70fac591763330bd75da`
- **Runtime:** net48, no NuGet dependencies beyond Harmony
- **Source directory:** `HudHooks`

**What it does:** a mod sends a mod message (id `2735914000`, payload `MyTuple<string, bool, bool>` as `(token, open, interceptEscape)`) to claim a token while its own HUD screen is open, and releases it on close. While any token is held the in-world crosshair is not drawn. Tokens that ask for it also swallow ESC, so the pause menu does not open over the mod's screen. Tokens are tracked per screen so several mods can hold hooks at once, and state is cleared on `OnSessionReady`.

**Patches:** two prefixes.
- `MyHudCrosshair.Draw` returns false while a token is held.
- `MyGuiSandbox.AddScreen` drops the main menu screen when the menu was opened by a new ESC press or the `MAIN_MENU` control while an intercept token is held, and pops the pause the constructor pushed in single player. It returns true in every other case, so the patch is a no-op unless a mod is actively holding a token.

**Failsafe:** two ESC presses within 500 ms always let the menu through, so a mod that fails to release its token cannot lock a player out.

**Compatibility:** client-side only, no world or network state, safe on any server.