### PR TITLE
Add Conveyor Helper (LYNX)

### DIFF
--- a/Plugins/ConveyorHelper.xml
+++ b/Plugins/ConveyorHelper.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
 
     <Id>KerboNerd/ConveyorHelper</Id>
@@ -12,7 +12,7 @@
 
 While you are placing a block, Conveyor Helper draws thick cyan markers on every conveyor port of the ghost, pointing outward so you can see how the block will connect before you confirm.
 
-Works with vanilla conveyors and modded ones (including AQD armored T/X/corner pieces) by reading the block's conveyor dummies — no per-mod setup.
+Works with vanilla conveyors and modded ones (including AQD armored T/X/corner pieces) by reading the block's conveyor dummies - no per-mod setup.
 
 Toggle on/off with NumPad * (configurable in the plugin settings). Visuals only; does not change placement rules or conveyor behavior.</Description>
 

--- a/Plugins/ConveyorHelper.xml
+++ b/Plugins/ConveyorHelper.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+
+    <Id>KerboNerd/ConveyorHelper</Id>
+    <RepoId>KerboNerd/ConveyorHelper</RepoId>
+
+    <FriendlyName>Conveyor Helper</FriendlyName>
+    <Author>LYNX</Author>
+
+    <Tooltip>Shows conveyor port directions on the placement ghost.</Tooltip>
+    <Description>Client-only placement helper for conveyor ports.
+
+While you are placing a block, Conveyor Helper draws thick cyan markers on every conveyor port of the ghost, pointing outward so you can see how the block will connect before you confirm.
+
+Works with vanilla conveyors and modded ones (including AQD armored T/X/corner pieces) by reading the block's conveyor dummies — no per-mod setup.
+
+Toggle on/off with NumPad * (configurable in the plugin settings). Visuals only; does not change placement rules or conveyor behavior.</Description>
+
+    <SourceDirectories>
+        <Directory>ClientPlugin</Directory>
+    </SourceDirectories>
+
+    <Commit>3d41d89a0dd28b38682a84322fae32f6b6a45653</Commit>
+
+</PluginData>

--- a/Plugins/ConveyorHelper.xml
+++ b/Plugins/ConveyorHelper.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
 
     <Id>KerboNerd/ConveyorHelper</Id>
@@ -12,7 +12,7 @@
 
 While you are placing a block, Conveyor Helper draws thick cyan markers on every conveyor port of the ghost, pointing outward so you can see how the block will connect before you confirm.
 
-Works with vanilla conveyors and modded ones (including AQD armored T/X/corner pieces) by reading the block's conveyor dummies — no per-mod setup.
+Works with vanilla conveyors and modded ones (including AQD armored T/X/corner pieces) by reading the block's conveyor dummies � no per-mod setup.
 
 Toggle on/off with NumPad * (configurable in the plugin settings). Visuals only; does not change placement rules or conveyor behavior.</Description>
 
@@ -20,6 +20,6 @@ Toggle on/off with NumPad * (configurable in the plugin settings). Visuals only;
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
 
-    <Commit>3d41d89a0dd28b38682a84322fae32f6b6a45653</Commit>
+    <Commit>3623f9ceb45c3b670dbab61ea1832a28131fb0bb</Commit>
 
 </PluginData>


### PR DESCRIPTION
## Summary
- Adds **Conveyor Helper**, a client-only Pulsar plugin by **LYNX**
- Shows conveyor port direction markers on the placement ghost (vanilla + modded, including AQD)
- Repo: https://github.com/KerboNerd/ConveyorHelper