### PR TITLE
GpsFolders: bump pin to v1.6.4 (fixes GPS-description crash)

### DIFF
--- a/Plugins/GpsFolders.xml
+++ b/Plugins/GpsFolders.xml
@@ -16,5 +16,5 @@ Other Features:
 - Distance in gps tooltip
   
 Visit the github page for more information.</Description>
-  <Commit>15cbe1165b2d797b6060502768d317610cd082c5</Commit>
+  <Commit>1376a89f3e1d86659e272ff35c43edb207e5138f</Commit>
 </PluginData>


### PR DESCRIPTION
Bumps the `GpsFolders` pin from `15cbe11` (v1.6.3, 2026-05-26) to `1376a89` (v1.6.4, 2026-07-31).

v1.6.4 is *"Fix crash on changing gps desc then selecting a folder row"*, but the hub still points at
v1.6.3, so no client can receive it.

### The crash it fixes

Reproduced three times on Pulsar v2.3.1 / SE 1.210.12. Adding a GPS folder after touching a GPS
description hard-crashes the client. Identical stack every time:

```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at System.Text.StringBuilder.get_Chars(Int32 index)
   at System.Text.StringBuilderExtensions_Format.AppendSubstring(StringBuilder stringBuilder, StringBuilder append, Int32 start, Int32 count)
   at Sandbox.Graphics.GUI.MyGuiControlMultilineEditableText.GetCarriageOffset(Int32 idx)
   at Sandbox.Graphics.GUI.MyGuiControlMultilineText.Draw(Single transitionAlpha, Single backgroundTransitionAlpha)
   at Sandbox.Graphics.GUI.MyGuiScreenBase.Draw()
   at Sandbox.Graphics.GUI.MyGuiSandbox.Draw()
   at Sandbox.MySandboxGame.PrepareForDraw()
```

It's a draw-time exception, so there's no recovery — the client dies immediately. The folder write
itself succeeds first, so the change is present after restarting, which makes it look intermittent.

Clearing the Pulsar plugin cache doesn't help, since the re-download resolves to the pinned commit.

### Verification

`1376a89f3e1d86659e272ff35c43edb207e5138f` is the current tip of `master` on `StarCpt/SE-GpsFolders`.
No other field changed.
