### PR TITLE
Add Tactical Faction Ping

### DIFF
--- a/Plugins/TacticalFactionPing.xml
+++ b/Plugins/TacticalFactionPing.xml
@@ -1,22 +1,22 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
 
     <Id>B64AC6ED-A9FD-4CF7-B577-5CBAA2398913</Id>
     <RepoId>InvalidArgument3/TacticalFactionPing</RepoId>
     <FriendlyName>Tactical Faction Ping</FriendlyName>
-    <Author>InvalidArgument3</Author>
+    <Author>Invalid</Author>
     <Tooltip>Private faction tactical GPS pings (look-dir / distance)</Tooltip>
     <Description>Client-only Pulsar plugin for private faction tactical pings.
 
 Place a look-direction ping with Shift+T (configurable), or /fping &lt;km&gt; &lt;name&gt;.
 Pings ride vanilla faction chat, appear as local GPS markers (one per player),
-with username-seeded or custom colors and a configurable cooldown.
+with username-seeded or custom colors and a 5s cooldown.
 
 Requires faction membership. All faction mates need the plugin to see pings.
 Repo: https://github.com/InvalidArgument3/TacticalFactionPing</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
-    <Commit>39bba188f32eabce892d39c760a0a49af6f34000</Commit>
+    <Commit>56840ef7e6ce6aaa041ec04ee0d053373b91d8fd</Commit>
 
 </PluginData>

--- a/Plugins/TacticalFactionPing.xml
+++ b/Plugins/TacticalFactionPing.xml
@@ -17,6 +17,6 @@ Repo: https://github.com/InvalidArgument3/TacticalFactionPing</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
-    <Commit>398fa81243cac69420aae371e6a9ab58b793f297</Commit>
+    <Commit>fbc706e20e3f2e4231b351c640ba8cc3c6550c5d</Commit>
 
 </PluginData>

--- a/Plugins/TacticalFactionPing.xml
+++ b/Plugins/TacticalFactionPing.xml
@@ -8,8 +8,8 @@
     <Tooltip>Private faction tactical GPS pings (look-dir / distance)</Tooltip>
     <Description>Client-only Pulsar plugin for private faction tactical pings.
 
-Place a look-direction ping with Shift+T (configurable), or /fping &lt;km&gt; &lt;name&gt;.
-Pings ride vanilla faction chat, appear as local GPS markers (one per player),
+Enter place mode with Shift+R (configurable): scroll distance (10m / Shift 100m / Ctrl 1km, max 100km), LMB confirm, RMB cancel. Or /fping &lt;km&gt; &lt;name&gt;.
+Pings ride vanilla faction GPS chat, appear as local GPS markers (one per player),
 with username-seeded or custom colors and a 5s cooldown.
 
 Requires faction membership. All faction mates need the plugin to see pings.
@@ -17,6 +17,6 @@ Repo: https://github.com/InvalidArgument3/TacticalFactionPing</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
-    <Commit>5fef81d77ad5e9fc98f9178fa8b635924ea9fba6</Commit>
+    <Commit>10be5eb8bb4d5433032d1ce38cec98031032434e</Commit>
 
 </PluginData>

--- a/Plugins/TacticalFactionPing.xml
+++ b/Plugins/TacticalFactionPing.xml
@@ -17,6 +17,6 @@ Repo: https://github.com/InvalidArgument3/TacticalFactionPing</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
-    <Commit>56840ef7e6ce6aaa041ec04ee0d053373b91d8fd</Commit>
+    <Commit>398fa81243cac69420aae371e6a9ab58b793f297</Commit>
 
 </PluginData>

--- a/Plugins/TacticalFactionPing.xml
+++ b/Plugins/TacticalFactionPing.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+
+    <Id>B64AC6ED-A9FD-4CF7-B577-5CBAA2398913</Id>
+    <RepoId>InvalidArgument3/TacticalFactionPing</RepoId>
+    <FriendlyName>Tactical Faction Ping</FriendlyName>
+    <Author>InvalidArgument3</Author>
+    <Tooltip>Private faction tactical GPS pings (look-dir / distance)</Tooltip>
+    <Description>Client-only Pulsar plugin for private faction tactical pings.
+
+Place a look-direction ping with Shift+T (configurable), or /fping &lt;km&gt; &lt;name&gt;.
+Pings ride vanilla faction chat, appear as local GPS markers (one per player),
+with username-seeded or custom colors and a configurable cooldown.
+
+Requires faction membership. All faction mates need the plugin to see pings.
+Repo: https://github.com/InvalidArgument3/TacticalFactionPing</Description>
+    <SourceDirectories>
+        <Directory>ClientPlugin</Directory>
+    </SourceDirectories>
+    <Commit>39bba188f32eabce892d39c760a0a49af6f34000</Commit>
+
+</PluginData>

--- a/Plugins/TacticalFactionPing.xml
+++ b/Plugins/TacticalFactionPing.xml
@@ -17,6 +17,6 @@ Repo: https://github.com/InvalidArgument3/TacticalFactionPing</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
-    <Commit>fbc706e20e3f2e4231b351c640ba8cc3c6550c5d</Commit>
+    <Commit>5fef81d77ad5e9fc98f9178fa8b635924ea9fba6</Commit>
 
 </PluginData>


### PR DESCRIPTION
- adds TacticalFactionPing
- faction gps sharing/GPS pings via vanilla faction chat, activate with shift + T
- https://github.com/InvalidArgument3/TacticalFactionPing