### PR TITLE
Add CleanFeed

### DIFF
--- a/Plugins/CleanFeed.xml
+++ b/Plugins/CleanFeed.xml
@@ -25,5 +25,5 @@ MIT. Source and issue reporting: https://github.com/arsnekfcn/CleanFeed</Descrip
     <Directory>Tools</Directory>
   </SourceDirectories>
   <Platforms>Windows</Platforms>
-  <Commit>de4e2056ba00c7670d6a521e248736b84c39ab27</Commit>
+  <Commit>4510fed181e311af7c2a94583c70759918e2d8e4</Commit>
 </PluginData>

--- a/Plugins/CleanFeed.xml
+++ b/Plugins/CleanFeed.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>arsnekfcn/CleanFeed</Id>
+  <FriendlyName>CleanFeed</FriendlyName>
+  <Author>arsnek</Author>
+  <Tooltip>Keep selected HUD elements visible while hiding them from supported game capture.</Tooltip>
+  <Description>Independent HUD privacy controls for Space Engineers recording and streaming.
+
+CleanFeed can leave selected HUD elements visible to the player while removing them from NVIDIA, OBS Game Capture, and other compatible game-capture recordings. Player visibility can also be configured independently, and an unfocused-window privacy guard prevents supported HUD from appearing in a stream during alt-tab.
+
+Explicit compatibility controls for vanilla HUD, HUDLCD, WeaponCore, WC Radar, Flight HUD, Flight Vector, Beaconless Thrust/Power Signals, Flip and Burn, GameCore's Hand Terminal, and BuildInfo's toolbar info panel, plus best-effort discovery for other HUD providers. Unsupported render paths remain visible and are reported in the settings screen.
+
+Requires Windows and Pulsar (Legacy or Interim), and windowed or fullscreen-window mode. Capture compatibility varies by recorder; Display Capture is not a clean-feed route.
+
+MIT. Source and issue reporting: https://github.com/arsnekfcn/CleanFeed</Description>
+  <SourceDirectories>
+    <Directory>Compatibility</Directory>
+    <Directory>Core</Directory>
+    <Directory>Diagnostics</Directory>
+    <Directory>Entrypoint</Directory>
+    <Directory>Overlay</Directory>
+    <Directory>Profiles</Directory>
+    <Directory>Render</Directory>
+    <Directory>Screens</Directory>
+    <Directory>Tools</Directory>
+  </SourceDirectories>
+  <Platforms>Windows</Platforms>
+  <Commit>317ce8050ba98167ccad90639b0bc0e007923fc1</Commit>
+</PluginData>

--- a/Plugins/CleanFeed.xml
+++ b/Plugins/CleanFeed.xml
@@ -25,5 +25,5 @@ MIT. Source and issue reporting: https://github.com/arsnekfcn/CleanFeed</Descrip
     <Directory>Tools</Directory>
   </SourceDirectories>
   <Platforms>Windows</Platforms>
-  <Commit>317ce8050ba98167ccad90639b0bc0e007923fc1</Commit>
+  <Commit>de4e2056ba00c7670d6a521e248736b84c39ab27</Commit>
 </PluginData>


### PR DESCRIPTION
CleanFeed splits the HUD into what the player sees and what a game capture records: filtered HUD elements render onto a DirectComposition surface over the game window, so NVIDIA/OBS game-capture reads the swapchain without them while the player keeps a full HUD. It is intended for content creators and streamers, so they can share footage from PvP servers without doxxing their own GPS coordinates, base locations, or fleet positions. Per-element recording filters and player visibility are independent, with an unfocused-window privacy guard for alt-tab.

- Source, user guide, and security policy: https://github.com/arsnekfcn/CleanFeed (MIT)
- Windows-only by mechanism (desktop composition); declared via `<Platforms>Windows</Platforms>`
- No `<Runtimes>` element - runs on Legacy and Interim, compatible with the newer runtime vocabulary
- No network access, no binaries, single profile file write; see SECURITY.md for the trust model
- Validated at the pinned commit: from-source compile and load through Pulsar `-sources` on both Legacy and Interim, plus extended live multiplayer testing with OBS/NVIDIA capture verification