### PR TITLE
Adds WelderPaint

### DIFF
--- a/Plugins/WelderPaint.xml
+++ b/Plugins/WelderPaint.xml
@@ -11,5 +11,5 @@ Pick a color or skin in the normal color picker (P) as usual, toggle paint mode 
 Targeting mirrors the welder's own highlight, so visually small blocks that own a whole cube cell (corner floor lamps, wall pictures) can be painted directly or aimed past to paint the floor/wall behind them.
 
 Uses the exact same server-validated paint request as vanilla block painting, so multiplayer ownership rules apply unchanged. Optional debug network logging for diagnostics.</Description>
-  <Commit>a50c8ad</Commit>
+  <Commit>a50c8ada5151ad85aef89be6e844bb8899dc634f</Commit>
 </PluginData>

--- a/Plugins/WelderPaint.xml
+++ b/Plugins/WelderPaint.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>dawidmachon/se-welder-paint</Id>
+  <FriendlyName>Welder Paint</FriendlyName>
+  <Author>dawidmachon</Author>
+  <Tooltip>Paint blocks by aiming a welder at them instead of using a ghost block</Tooltip>
+  <Description>Repaint blocks by aiming your welder at them and pressing the left mouse button - no need to hold a block in hand and touch its sides with the ghost, which is tedious for small or decorative blocks.
+
+Pick a color or skin in the normal color picker (P) as usual, toggle paint mode with a configurable keybind (default O), aim, click. Hold the left mouse button to paint continuously.
+
+Targeting mirrors the welder's own highlight, so visually small blocks that own a whole cube cell (corner floor lamps, wall pictures) can be painted directly or aimed past to paint the floor/wall behind them.
+
+Uses the exact same server-validated paint request as vanilla block painting, so multiplayer ownership rules apply unchanged. Optional debug network logging for diagnostics.</Description>
+  <Commit>385e8be895b933afdbbc27c061b0ec7d383cf846</Commit>
+</PluginData>

--- a/Plugins/WelderPaint.xml
+++ b/Plugins/WelderPaint.xml
@@ -11,5 +11,5 @@ Pick a color or skin in the normal color picker (P) as usual, toggle paint mode 
 Targeting mirrors the welder's own highlight, so visually small blocks that own a whole cube cell (corner floor lamps, wall pictures) can be painted directly or aimed past to paint the floor/wall behind them.
 
 Uses the exact same server-validated paint request as vanilla block painting, so multiplayer ownership rules apply unchanged. Optional debug network logging for diagnostics.</Description>
-  <Commit>385e8be895b933afdbbc27c061b0ec7d383cf846</Commit>
+  <Commit>a50c8ad</Commit>
 </PluginData>


### PR DESCRIPTION
Adds **Welder Paint** — a client plugin that lets players repaint blocks by aiming a welder at them, instead of the vanilla block-in-hand ghost painting.

- Pick color/skin in the normal P palette, toggle paint mode with a configurable keybind (default `O`), aim, LMB. Hold LMB to paint continuously.
- Targeting mirrors the vanilla tool highlight (collision + visual AABB, nearest wins), so visually small blocks that own a whole cube cell (corner floor lamps, wall pictures) can be painted directly or aimed past to paint the block behind.
- Uses the exact same server-validated `SkinBlocks` request as vanilla painting — multiplayer ownership rules apply unchanged.
- Optional debug network logging of paint traffic (off by default).
- MIT licensed, tested in singleplayer and on a multiplayer server (including hybrid .NET 10/Legacy-loader setups).