### PR TITLE
ADD OREO SYSTEMS // BETA client mod

### DIFF
--- a/Plugins/Mods/OreoRoacherClient.xml
+++ b/Plugins/Mods/OreoRoacherClient.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:type="ModPlugin">
+  <Id>3789098420</Id>
+  <FriendlyName>OREO SYSTEMS // BETA</FriendlyName>
+  <Author>austinog92-afk</Author>
+  <Tooltip>Client-side OREO SYSTEMS beta HUD, allegiance, progression and WeaponCore combat UI.</Tooltip>
+  <Description>Client-side OREO SYSTEMS beta HUD with Lion/Dragon allegiance, evolving rank and faction icons, and persistent mastery/career progression. Uses Rich HUD Framework and reads WeaponCore / Defense Shields APIs without requiring an Oreo server mod.</Description>
+  <Hidden>true</Hidden>
+  <DependencyIds>
+    <Id>1965654081</Id>
+  </DependencyIds>
+</PluginData>


### PR DESCRIPTION
Adds the OREO SYSTEMS // BETA client-side mod.

Steam Workshop ID: 3789098420
Dependency: Rich HUD Master (1965654081)
Currently unlisted for beta testing.