### PR TITLE
Update Paint Jobs to #2beb1785

### DIFF
--- a/Plugins/PaintJob.xml
+++ b/Plugins/PaintJob.xml
@@ -3,28 +3,23 @@
   <Id>rosudrag/se-paintjob</Id>
   <FriendlyName>Paint Jobs</FriendlyName>
   <Author>rosudrag</Author>
-  <Tooltip>Professional paint designer with GUI - 7 styles, 30+ variants including military, racing, pirate, alien &amp; more!</Tooltip>
+  <Tooltip>Paints a whole grid in one click - 8 styles, 37 variants, undo and reroll</Tooltip>
   <Description>
-Transform your grids with professional paint jobs through an intuitive GUI interface!
+Paint Jobs gives a grid a coherent paint scheme in one click - colour and armour skin together, symmetric, and derived from the grid's own shape, so a fighter and a mining rig in the same style still look nothing alike.
 
-FEATURES:
-• User-friendly GUI: No complex commands needed - just point and paint!
-• 7 unique paint styles with 30+ total variants
-• Advanced painting system with gradient effects and pattern generation
-• Smart ship analysis for intelligent color placement
-• Navigation lights: Automatic port (red) &amp; starboard (green) lighting
-• Unique variations: Each grid gets unique colors based on its ID
-• Range-based selection: Paint grids within 500m that you own
+8 styles, 37 variants: Military, Racing, Pirate, Corporate, Alien, Retro, Rudimentary, and Custom, which builds a harmony around any hue you pick (mono, analogous, complementary, split, triad, tetrad). Nav lights come out port red and starboard green, and only skins you actually own get used.
 
-HOW TO USE:
-1. Type /paint to open the Paint Designer GUI
-2. Select your grid from the dropdown (must be within 500m and owned by you)
-3. Choose a paint style and variant
-4. Click Apply to transform your grid instantly!
+Type /paint, pick a grid within 500m that you own, choose a style, hit Apply. Don't like the result? Reroll for a new seed, or Undo to put it back the way it was.
 
-COMMANDS:
-/paint - Open the Paint Designer GUI
-/paint help - Show help information
+Chat commands, if you prefer them:
+/paint &lt;style&gt; [variant] [--hue 0-360] [--nonce n]
+/paint undo | reroll | list [style] | help
+
+Bugs and requests: https://github.com/rosudrag/se-paintjob/issues
   </Description>
-  <Commit>454d695a3f237c2e032b4533b32d0562b0facb9a</Commit>
+  <SourceDirectories>
+    <Directory>PaintJob</Directory>
+    <Directory>Shared</Directory>
+  </SourceDirectories>
+  <Commit>7f474f7d1065894579fa44d098436878fb1948e2</Commit>
 </PluginData>

--- a/Plugins/PaintJob.xml
+++ b/Plugins/PaintJob.xml
@@ -26,5 +26,5 @@ COMMANDS:
 /paint - Open the Paint Designer GUI
 /paint help - Show help information
   </Description>
-  <Commit>df26ca34d02e94e7c9bc3ce51d12659031167605</Commit>
+  <Commit>454d695a3f237c2e032b4533b32d0562b0facb9a</Commit>
 </PluginData>

--- a/Plugins/PaintJob.xml
+++ b/Plugins/PaintJob.xml
@@ -3,17 +3,17 @@
   <Id>rosudrag/se-paintjob</Id>
   <FriendlyName>Paint Jobs</FriendlyName>
   <Author>rosudrag</Author>
-  <Tooltip>Paints a whole grid in one click - 8 styles, 37 variants, undo and reroll</Tooltip>
+  <Tooltip>Paints a whole grid in one click - 134 schemes, undo and reroll</Tooltip>
   <Description>
 Paint Jobs gives a grid a coherent paint scheme in one click - colour and armour skin together, symmetric, and derived from the grid's own shape, so a fighter and a mining rig in the same style still look nothing alike.
 
-8 styles, 37 variants: Military, Racing, Pirate, Corporate, Alien, Retro, Rudimentary, and Custom, which builds a harmony around any hue you pick (mono, analogous, complementary, split, triad, tetrad). Nav lights come out port red and starboard green, and only skins you actually own get used.
+134 schemes in 6 collections, picked as collection, then faction, then variant. Classic holds the original 8 styles, including Custom, which builds a harmony around any hue you pick (mono, analogous, complementary, split, triad, tetrad). Alongside it: The Expanse (UNN, MCRN, Belter, Free Navy, Protogen), Star Wars (Empire, Rebellion, Republic, Separatist, Mandalorian, First Order), Star Trek (Starfleet, Klingon, Romulan, Borg, Cardassian, Ferengi), Warhammer 40,000 (Ultramarines, Blood Angels, Imperial Navy, Adeptus Mechanicus, Necrons, Orks) and Stargate (Tau'ri, Goa'uld, Asgard, Wraith, Ori, Replicators). Nav lights come out port red and starboard green - unless the faction has none - and only skins you actually own get used.
 
-Type /paint, pick a grid within 500m that you own, choose a style, hit Apply. Don't like the result? Reroll for a new seed, or Undo to put it back the way it was.
+Type /paint, pick a grid within 500m that you own, choose a scheme, hit Apply. Don't like the result? Reroll for a new seed, or Undo to put it back the way it was.
 
 Chat commands, if you prefer them:
-/paint &lt;style&gt; [variant] [--hue 0-360] [--nonce n]
-/paint undo | reroll | list [style] | help
+/paint &lt;collection&gt; &lt;faction&gt; [variant] [--hue 0-360] [--nonce n]
+/paint undo | reroll | list [collection] [faction] | help
 
 Bugs and requests: https://github.com/rosudrag/se-paintjob/issues
   </Description>
@@ -21,5 +21,5 @@ Bugs and requests: https://github.com/rosudrag/se-paintjob/issues
     <Directory>PaintJob</Directory>
     <Directory>Shared</Directory>
   </SourceDirectories>
-  <Commit>7f474f7d1065894579fa44d098436878fb1948e2</Commit>
+  <Commit>2beb1785ecc6cbd1908db736b0926a1b0febf06a</Commit>
 </PluginData>


### PR DESCRIPTION
Bumps the pinned commit to 2beb1785.

That build adds a third level to the scheme catalogue: schemes are picked as collection, then faction, then variant. Five franchise collections ship alongside the original eight styles (now grouped under Classic), for 134 schemes across 34 factions.

The listing copy changes with the hash rather than after it, because the old text is no longer true:

- Tooltip and description said "8 styles, 37 variants".
- The documented chat grammar was the two-level form, so anyone reading the hub entry would have been handed the wrong command. It now reads `/paint <collection> <faction> [variant]` and `/paint list [collection] [faction]`.

Validated with `python test.py Plugins/` before pushing.
