### PR TITLE
Add Tool Switcher plugin

### DIFF
--- a/Plugins/ToolSwitcher.xml
+++ b/Plugins/ToolSwitcher.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
   <Id>austinvaness/ToolSwitcherPlugin</Id>
+  <RepoId>Squeech007/ToolSwitcherPlugin</RepoId>
    
   <FriendlyName>Tool Switcher</FriendlyName>
-  <Author>avaness</Author>
+  <Author>avaness / Squeech007</Author>
   <Tooltip>Allows scrolling between welder, grinder, and drill.</Tooltip>
-  <Commit>eeca2869224bb99a34542c5e40b5ac6912b08cbc</Commit>
+  <Commit>cc38a43d038cee969f36654c140d98f3beebafec</Commit>
   <Description>This plugin is a simplified version of the Tool Switcher mod. It allows you to scroll between the welder, grinder, and drill. There is no configuration yet, so these tools will always be grouped together while the plugin is enabled. The benefits of this plugin over the mod are that you can use any toolbar page, and it will work on any multiplayer server.</Description>
 </PluginData>

--- a/Plugins/ToolSwitcherPlugin.xml
+++ b/Plugins/ToolSwitcherPlugin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>Squeech007/ToolSwitcherPlugin</Id>
+  <FriendlyName>Tool Switcher</FriendlyName>
+  <Author>austinvaness / Squeech007</Author>
+  <Tooltip>Automatically switches to the appropriate tool when cycling the toolbar.</Tooltip>
+  <Description>Automatically switches to the appropriate tool when cycling the toolbar, with fast player-change detection for Nexus seamless server switching.</Description>
+  <Commit>cc38a43d038cee969f36654c140d98f3beebafec</Commit>
+</PluginData>

--- a/Plugins/ToolSwitcherPlugin.xml
+++ b/Plugins/ToolSwitcherPlugin.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
-  <Id>Squeech007/ToolSwitcherPlugin</Id>
-  <FriendlyName>Tool Switcher</FriendlyName>
-  <Author>austinvaness / Squeech007</Author>
-  <Tooltip>Automatically switches to the appropriate tool when cycling the toolbar.</Tooltip>
-  <Description>Automatically switches to the appropriate tool when cycling the toolbar, with fast player-change detection for Nexus seamless server switching.</Description>
-  <Commit>cc38a43d038cee969f36654c140d98f3beebafec</Commit>
-</PluginData>


### PR DESCRIPTION
Adds ToolSwitcherPlugin to PluginHub. The current version includes fast player-change detection for Nexus seamless server switching.