### PR TITLE
Atomic.FM plugin

### DIFF
--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -35,6 +35,6 @@ https://github.com/TomasServo/atomic.fm
     <Platforms>Windows</Platforms>
     <Hidden>false</Hidden>
 
-    <Commit>3924b7fff2d36a8da33c781f5f1d39de27384b85</Commit>
+    <Commit>6e94cd22dc05151a03d5f42103c4b1e46be3b408</Commit>
 
 </PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -35,6 +35,6 @@ https://github.com/TomasServo/atomic.fm
     <Platforms>Windows</Platforms>
     <Hidden>false</Hidden>
 
-    <Commit>6e94cd22dc05151a03d5f42103c4b1e46be3b408</Commit>
+    <Commit>86a242f074786f27b81a8da1c19202dd03fe821c</Commit>
 
 </PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -9,7 +9,7 @@
 
 atomic.fm brings live internet radio, music, and ambient station audio to Space Engineers through Pulsar. Tune into an Icecast stream in the client, or turn almost any terminal block into a spatial radio source by adding atomic.fm=true to Custom Data.
 
-Use it for lounges, bars, ships, stations, hangars, stores, events, faction bases, and server communities that want music without adding a server mod. Optional per-block settings include atomic.fm.range=35 and atomic.fm.volume=5.5. Ctrl+Alt+M toggles playback manually. Audio is client-side, so each player chooses whether to install, enable, and hear atomic.fm.</Description>
+Use it for lounges, bars, ships, stations, hangars, stores, events, faction bases, and server communities that want music without adding a server mod. Optional per-block settings include atomic.fm.range=35 and atomic.fm.volume=5.5 on a 0-11 scale. Ctrl+Alt+M toggles playback manually. Audio is client-side, so each player chooses whether to install, enable, and hear atomic.fm.</Description>
   <SourceDirectories>
     <Directory>ClientPlugin</Directory>
   </SourceDirectories>
@@ -19,5 +19,5 @@ Use it for lounges, bars, ships, stations, hangars, stores, events, faction base
     <PackageReference Include="NAudio" Version="2.2.1" />
   </NuGetReferences>
   <Hidden>false</Hidden>
-  <Commit>7ecb49095755a7adc839604612750096c0323b92</Commit>
+  <Commit>5f24270932300a9a85b2a04407c0252eff84bbb8</Commit>
 </PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+
+    <Id>TomasServo/atomic.fm</Id>
+    <RepoId>TomasServo/atomicfm</RepoId>
+
+    <FriendlyName>Atomic.FM</FriendlyName>
+    <Author>TomasServo</Author>
+
+    <Tooltip>All Ultralounge all the time — client-side internet radio for Space Engineers.</Tooltip>
+
+    <Description>All Ultralounge all the time.
+
+Atomic.FM streams radio.atomic.fm into Space Engineers through Pulsar. Mark any terminal block as a radio source in Custom Data:
+
+atomic.fm=true
+atomic.fm.range=35
+atomic.fm.volume=1.0
+
+Volume scale is 0–11 (11 is max). The stream starts near marked blocks with distance fade and stereo pan. Plain armor blocks do not work. Audio is client-side.
+
+Controls: Ctrl+Alt+M toggles playback.
+
+https://github.com/TomasServo/atomicfm
+    </Description>
+
+    <SourceDirectories>
+        <Directory>ClientPlugin</Directory>
+    </SourceDirectories>
+
+    <NuGetReferences>
+        <PackageReference Include="NAudio" Version="2.2.1" />
+    </NuGetReferences>
+
+    <Platforms>Windows</Platforms>
+    <Hidden>false</Hidden>
+
+    <!-- Pulsar builds this commit from RepoId after it exists on GitHub -->
+    <Commit>0933c143bf5202d1a80e92135f69ed933f4ae4fe</Commit>
+
+</PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -2,7 +2,7 @@
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
 
     <Id>TomasServo/atomic.fm</Id>
-    <RepoId>TomasServo/atomicfm</RepoId>
+    <RepoId>TomasServo/atomic.fm</RepoId>
 
     <FriendlyName>Atomic.FM</FriendlyName>
     <Author>TomasServo</Author>
@@ -21,7 +21,7 @@ Volume scale is 0–11 (11 is max). The stream starts near marked blocks with di
 
 Controls: Ctrl+Alt+M toggles playback.
 
-https://github.com/TomasServo/atomicfm
+https://github.com/TomasServo/atomic.fm
     </Description>
 
     <SourceDirectories>
@@ -35,7 +35,6 @@ https://github.com/TomasServo/atomicfm
     <Platforms>Windows</Platforms>
     <Hidden>false</Hidden>
 
-    <!-- Pulsar builds this commit from RepoId after it exists on GitHub -->
-    <Commit>0933c143bf5202d1a80e92135f69ed933f4ae4fe</Commit>
+    <Commit>40365b6860a5ed28973c060a0f880fc9149dbe0d</Commit>
 
 </PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -35,6 +35,6 @@ https://github.com/TomasServo/atomic.fm
     <Platforms>Windows</Platforms>
     <Hidden>false</Hidden>
 
-    <Commit>40365b6860a5ed28973c060a0f880fc9149dbe0d</Commit>
+    <Commit>5cb92a8645372c297e05f295cb1a2cdcaf017f26</Commit>
 
 </PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -1,40 +1,23 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="utf-8"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+  <Id>TomasServo/atomic.fm</Id>
+  <RepoId>TomasServo/atomic.fm</RepoId>
+  <FriendlyName>atomic.fm</FriendlyName>
+  <Author>TomasServo</Author>
+  <Tooltip>Streams atomic.fm from Icecast into the Space Engineers client.</Tooltip>
+  <Description>All Ultralounge all the time.
 
-    <Id>TomasServo/atomic.fm</Id>
-    <RepoId>TomasServo/atomic.fm</RepoId>
+atomic.fm brings live internet radio, music, and ambient station audio to Space Engineers through Pulsar. Tune into an Icecast stream in the client, or turn almost any terminal block into a spatial radio source by adding atomic.fm=true to Custom Data.
 
-    <FriendlyName>Atomic.FM</FriendlyName>
-    <Author>TomasServo</Author>
-
-    <Tooltip>All Ultralounge all the time — client-side internet radio for Space Engineers.</Tooltip>
-
-    <Description>All Ultralounge all the time.
-
-Atomic.FM streams radio.atomic.fm into Space Engineers through Pulsar. Mark any terminal block as a radio source in Custom Data:
-
-atomic.fm=true
-atomic.fm.range=35
-atomic.fm.volume=1.0
-
-Volume scale is 0–11 (11 is max). The stream starts near marked blocks with distance fade and stereo pan. Plain armor blocks do not work. Audio is client-side.
-
-Controls: Ctrl+Alt+M toggles playback.
-
-https://github.com/TomasServo/atomic.fm
-    </Description>
-
-    <SourceDirectories>
-        <Directory>ClientPlugin</Directory>
-    </SourceDirectories>
-
-    <NuGetReferences>
-        <PackageReference Include="NAudio" Version="2.2.1" />
-    </NuGetReferences>
-
-    <Platforms>Windows</Platforms>
-    <Hidden>false</Hidden>
-
-    <Commit>fb7c3e1ac43e4258cd08653e9106ec1c95cac09e</Commit>
-
+Use it for lounges, bars, ships, stations, hangars, stores, events, faction bases, and server communities that want music without adding a server mod. Optional per-block settings include atomic.fm.range=35 and atomic.fm.volume=5.5. Ctrl+Alt+M toggles playback manually. Audio is client-side, so each player chooses whether to install, enable, and hear atomic.fm.</Description>
+  <SourceDirectories>
+    <Directory>ClientPlugin</Directory>
+  </SourceDirectories>
+  <Runtimes>CLR;Mono</Runtimes>
+  <Platforms>Windows</Platforms>
+  <NuGetReferences>
+    <PackageReference Include="NAudio" Version="2.2.1" />
+  </NuGetReferences>
+  <Hidden>false</Hidden>
+  <Commit>7ecb49095755a7adc839604612750096c0323b92</Commit>
 </PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -35,6 +35,6 @@ https://github.com/TomasServo/atomic.fm
     <Platforms>Windows</Platforms>
     <Hidden>false</Hidden>
 
-    <Commit>5cb92a8645372c297e05f295cb1a2cdcaf017f26</Commit>
+    <Commit>3924b7fff2d36a8da33c781f5f1d39de27384b85</Commit>
 
 </PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -35,6 +35,6 @@ https://github.com/TomasServo/atomic.fm
     <Platforms>Windows</Platforms>
     <Hidden>false</Hidden>
 
-    <Commit>86a242f074786f27b81a8da1c19202dd03fe821c</Commit>
+    <Commit>fb7c3e1ac43e4258cd08653e9106ec1c95cac09e</Commit>
 
 </PluginData>

--- a/Plugins/atomic.fm.xml
+++ b/Plugins/atomic.fm.xml
@@ -7,17 +7,17 @@
   <Tooltip>Streams atomic.fm from Icecast into the Space Engineers client.</Tooltip>
   <Description>All Ultralounge all the time.
 
-atomic.fm brings live internet radio, music, and ambient station audio to Space Engineers through Pulsar. Tune into an Icecast stream in the client, or turn almost any terminal block into a spatial radio source by adding atomic.fm=true to Custom Data.
+atomic.fm brings live internet radio, music, and ambient station audio to Space Engineers through Pulsar. Tune into the default Icecast stream at http://radio.atomic.fm:8000/atomic-radio, or turn almost any terminal block into a spatial radio source by adding atomic.fm=true to Custom Data.
 
-Use it for lounges, bars, ships, stations, hangars, stores, events, faction bases, and server communities that want music without adding a server mod. Optional per-block settings include atomic.fm.range=35 and atomic.fm.volume=5.5 on a 0-11 scale. Ctrl+Alt+M toggles playback manually. Audio is client-side, so each player chooses whether to install, enable, and hear atomic.fm.</Description>
+Use it for lounges, bars, ships, stations, hangars, stores, events, faction bases, and server communities that want music without adding a server mod. Optional per-block settings include atomic.fm.range=35 and atomic.fm.volume=5.5 on a 0-11 scale. Ctrl+Alt+M toggles playback manually. Audio is client-side; the default stream uses plain HTTP and exposes listener IPs to the author-operated station server.</Description>
   <SourceDirectories>
     <Directory>ClientPlugin</Directory>
   </SourceDirectories>
-  <Runtimes>CLR;Mono</Runtimes>
+  <Runtimes>NETFramework;CLR;Mono</Runtimes>
   <Platforms>Windows</Platforms>
   <NuGetReferences>
     <PackageReference Include="NAudio" Version="2.2.1" />
   </NuGetReferences>
   <Hidden>false</Hidden>
-  <Commit>5f24270932300a9a85b2a04407c0252eff84bbb8</Commit>
+  <Commit>57760875c827326f8121c35eadd91c5435a11cfa</Commit>
 </PluginData>


### PR DESCRIPTION
Atomic.FM: All Ultralounge all the time

Atomic.FM streams radio.atomic.fm into Space Engineers through Pulsar. Mark any terminal block as a radio source in Custom Data:

atomic.fm=true
atomic.fm.range=35
atomic.fm.volume=1.0

Volume scale is 0–11 (11 is max). The stream starts near marked blocks with distance fade and stereo pan. Plain armor blocks do not work. Audio is client-side.

Controls: Ctrl+Alt+M toggles playback.
