### PR TITLE
Add "NVIDIA DLSS" & "Anomaly Shader Framework"

### DIFF
--- a/Plugins/Anomaly.xml
+++ b/Plugins/Anomaly.xml
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+
+    <!-- Stable plugin id. Never change this. PluginHub consumers depend on it. -->
+    <Id>A9C29274-E447-49EE-881B-C980E6D190FD</Id>
+    <RepoId>PhoenixTheSage/Anomaly</RepoId>
+    <FriendlyName>Anomaly Shader Framework</FriendlyName>
+    <Author>PhoenixTheSage</Author>
+    <Tooltip>Shader Framework for Space Engineers</Tooltip>
+    <Description>
+Does nothing on its own. API that provides a common layer for shaders and advanced rendering.
+
+Documentation to come at a later date. Currently mainly used by DLSS plugin for testing.
+    </Description>
+
+    <SourceDirectories>
+        <Directory>ClientPlugin</Directory>
+        <Directory>Assets</Directory>
+    </SourceDirectories>
+
+    <!-- Pulsar 2.3.1 copies this tree and calls LoadAssets(string). Named Asset / Platforms tags are post-2.3.1. -->
+    <AssetFolder>Assets</AssetFolder>
+
+    <Hidden>false</Hidden>
+
+    <Commit>acb16cef0af7898ceadef7119ddb07ee04a2b513</Commit>
+
+</PluginData>

--- a/Plugins/Anomaly.xml
+++ b/Plugins/Anomaly.xml
@@ -23,6 +23,12 @@ Documentation to come at a later date. Currently mainly used by DLSS plugin for 
 
     <Hidden>false</Hidden>
 
-    <Commit>acb16cef0af7898ceadef7119ddb07ee04a2b513</Commit>
+    <!-- Rich HUD Master is optional. Settings stay on the Pulsar MyGui dialog
+         until a terminal page is added. -->
+    <SoftDependencyIds>
+        <Id>1965654081</Id>
+    </SoftDependencyIds>
+
+    <Commit>83a143fd39ba3dc5d0b6fe3dc146527e4462ff77</Commit>
 
 </PluginData>

--- a/Plugins/Anomaly.xml
+++ b/Plugins/Anomaly.xml
@@ -9,26 +9,16 @@
     <Tooltip>Shader Framework for Space Engineers</Tooltip>
     <Description>
 Does nothing on its own. API that provides a common layer for shaders and advanced rendering.
-
-Documentation to come at a later date. Currently mainly used by DLSS plugin for testing.
     </Description>
 
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
-        <Directory>Assets</Directory>
     </SourceDirectories>
 
-    <!-- Pulsar 2.3.1 copies this tree and calls LoadAssets(string). Named Asset / Platforms tags are post-2.3.1. -->
-    <AssetFolder>Assets</AssetFolder>
+    <Asset Name="AssetFolder" Path="Assets/" />
 
     <Hidden>false</Hidden>
 
-    <!-- Rich HUD Master is optional. Settings stay on the Pulsar MyGui dialog
-         until a terminal page is added. -->
-    <SoftDependencyIds>
-        <Id>1965654081</Id>
-    </SoftDependencyIds>
-
-    <Commit>83a143fd39ba3dc5d0b6fe3dc146527e4462ff77</Commit>
+    <Commit>0d8addf793f2aac7d569d1012bc76fe80972d080</Commit>
 
 </PluginData>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -3,11 +3,11 @@
 
     <Id>B6469FEE-83BF-44A9-93F9-B4A252527C35</Id>
     <RepoId>PhoenixTheSage/SE-DLSS</RepoId>
-    <FriendlyName>Zeridian DLSS 4.5</FriendlyName>
+    <FriendlyName>Zeridian's DLSS 4.5</FriendlyName>
     <Author>PhoenixTheSage</Author>
     <Tooltip>Enables DLSS 4.5 in Space Engineers</Tooltip>
     <Description>
-Adds NVIDIA DLSS & DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable GPU. Has built-in support for Rich HUD Framework.
+Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable GPU. Has built-in support for Rich HUD Framework.
     </Description>
 
     <SourceDirectories>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -26,6 +26,6 @@ Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable 
 
     <Platforms>Windows</Platforms>
 
-    <Commit>32a0e73f8a4e69e80d0070de70d25e52aa38e454</Commit>
+    <Commit>ef9d5976ffca94130c320ffb86e900df5b950df1</Commit>
 
 </PluginData>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+
+    <Id>B6469FEE-83BF-44A9-93F9-B4A252527C35</Id>
+    <RepoId>PhoenixTheSage/SE-DLSS</RepoId>
+    <FriendlyName>Zeridian DLSS 4.5</FriendlyName>
+    <Author>PhoenixTheSage</Author>
+    <Tooltip>Enables DLSS 4.5 in Space Engineers</Tooltip>
+    <Description>
+Adds NVIDIA DLSS & DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable GPU. Has built-in support for Rich HUD Framework.
+    </Description>
+
+    <SourceDirectories>
+        <Directory>ClientPlugin</Directory>
+    </SourceDirectories>
+
+    <!-- Pulsar copies this folder and calls Plugin.LoadAssets with its path.
+         Place SeDlssNgx.dll (native wrapper) and NVIDIA's nvngx_dlss.dll here. -->
+    <AssetFolder>Assets</AssetFolder>
+
+    <NuGetReferences>
+      <PackageReference Include="Lib.Harmony" Version="2.4.2" />
+      <PackageReference Include="Krafs.Publicizer" Version="2.3.0" />
+    </NuGetReferences>
+
+    <Platforms>Windows</Platforms>
+
+    <Commit>428ce9fbd051ba6d3145cd152b30fd14046219e7</Commit>
+
+</PluginData>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -12,20 +12,19 @@ Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable 
 
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
-        <Directory>Assets</Directory>
     </SourceDirectories>
 
-    <!-- Pulsar copies this folder and calls Plugin.LoadAssets with its path.
-         Place SeDlssNgx.dll (native wrapper) and NVIDIA's nvngx_dlss.dll here. -->
-    <AssetFolder>Assets</AssetFolder>
+    <!-- NVIDIA DLSS redistributable. Placement=Bin copies it next to plugin.dll.
+         Path is in-repo; -->
+    <Asset Name="NvngxDlss"
+           Path="Assets/nvngx_dlss.dll"
+           Placement="Bin" />
 
-    <NuGetReferences>
-      <PackageReference Include="Lib.Harmony" Version="2.4.2" />
-      <PackageReference Include="Krafs.Publicizer" Version="2.3.0" />
-    </NuGetReferences>
+    <!-- Anomaly is optional and discovered at runtime. Do not add DependencyIds
+         until Anomaly is on PluginHub; camera motion vectors remain the fallback. -->
 
     <Platforms>Windows</Platforms>
 
-    <Commit>ef9d5976ffca94130c320ffb86e900df5b950df1</Commit>
+    <Commit>c58590a1d908b514d3da40f38d2cc81cfefdf179</Commit>
 
 </PluginData>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -12,19 +12,21 @@ Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable 
 
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
+        <Directory>Assets</Directory>
     </SourceDirectories>
 
     <!-- NVIDIA DLSS redistributable. Placement=Bin copies it next to plugin.dll.
          Path is in-repo; -->
-    <Asset Name="NvngxDlss"
+    <!-- <Asset Name="NvngxDlss"
            Path="Assets/nvngx_dlss.dll"
-           Placement="Bin" />
+           Placement="Bin" /> -->
+    <AssetFolder>Assets</AssetFolder>
 
     <!-- Anomaly is optional and discovered at runtime. Do not add DependencyIds
          until Anomaly is on PluginHub; camera motion vectors remain the fallback. -->
 
     <Platforms>Windows</Platforms>
 
-    <Commit>c58590a1d908b514d3da40f38d2cc81cfefdf179</Commit>
+    <Commit>c6bc836ce1e4bf20894c73d192b33693274c2dfe</Commit>
 
 </PluginData>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -12,6 +12,7 @@ Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable 
 
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
+        <Directory>Assets</Directory>
     </SourceDirectories>
 
     <!-- Pulsar copies this folder and calls Plugin.LoadAssets with its path.
@@ -25,6 +26,6 @@ Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable 
 
     <Platforms>Windows</Platforms>
 
-    <Commit>428ce9fbd051ba6d3145cd152b30fd14046219e7</Commit>
+    <Commit>32a0e73f8a4e69e80d0070de70d25e52aa38e454</Commit>
 
 </PluginData>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -5,15 +5,14 @@
     <RepoId>PhoenixTheSage/SE-DLSS</RepoId>
     <FriendlyName>NVIDIA DLSS</FriendlyName>
     <Author>PhoenixTheSage</Author>
-    <Tooltip>Enables NVIDIA DLSS Super Resolution and DLAA in Space Engineers</Tooltip>
+    <Tooltip>Enables NVIDIA DLSS and DLAA 4.5</Tooltip>
     <Description>
-Adds NVIDIA DLSS Super Resolution and DLAA. Windows, NVIDIA RTX required. Defaults off.
+Adds NVIDIA DLSS and DLAA 4.5 in Space Engineers. NVIDIA RTX required.
 
-Loads the NVIDIA driver's private _nvngx.dll (System32, NGXCore, or DriverStore) through an OleAut32 trampoline. A native access violation during init cannot be caught from .NET Framework and will close the game. Other failures fail closed.
+Optional Anomaly Shader Framework supplies object motion to prevent ghosting. 
+Rich HUD is supported.
 
-Do not enable with HdrRender, SMAA, or SmoothFrames (tone-map, copy-to-RT, billboard, and camera-jitter overlap). Safer paths: HdrRender - use one or the other until an AfterUpscale/HDR-evaluate hook exists; SMAA - use DLSS or SMAA as the AA, not both; SmoothFrames - disable camera interpolation while DLSS is on.
-
-Optional Anomaly Shader Framework supplies object motion. Rich HUD is supported.
+Compat: Certain rendering mods may not play nice until they use Anomaly.
     </Description>
 
     <SourceDirectories>
@@ -24,12 +23,6 @@ Optional Anomaly Shader Framework supplies object motion. Rich HUD is supported.
            Url="https://github.com/PhoenixTheSage/SE-DLSS/releases/download/nvngx-dlss-310.7.0/nvngx_dlss.dll"
            Sha256="be6e434a94ca32499515eb62ca0e6c274526055d568d0426e4c652dcdfb6ee6e"
            Placement="Bin" />
-
-    <!-- Anomaly is optional and discovered at runtime. Camera motion vectors
-         remain the fallback when it is not enabled. -->
-    <SoftDependencyIds>
-        <Id>A9C29274-E447-49EE-881B-C980E6D190FD</Id>
-    </SoftDependencyIds>
 
     <Platforms>Windows</Platforms>
 

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -7,7 +7,13 @@
     <Author>PhoenixTheSage</Author>
     <Tooltip>Enables DLSS 4.5 in Space Engineers</Tooltip>
     <Description>
-Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable GPU. Has built-in support for Rich HUD Framework.
+Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. 
+
+Requires NVIDA DLSS-capable GPU.
+Built-in support for Rich HUD Framework.
+Built-in support for Anomaly Shader Framework.
+
+Anomaly is highly recommended as it provides real motion vectors that remove ghosting.
     </Description>
 
     <SourceDirectories>
@@ -22,11 +28,14 @@ Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable 
            Placement="Bin" /> -->
     <AssetFolder>Assets</AssetFolder>
 
-    <!-- Anomaly is optional and discovered at runtime. Do not add DependencyIds
-         until Anomaly is on PluginHub; camera motion vectors remain the fallback. -->
+    <!-- Anomaly is optional and discovered at runtime. Camera motion vectors
+         remain the fallback when it is not enabled. -->
+    <SoftDependencyIds>
+        <Id>A9C29274-E447-49EE-881B-C980E6D190FD</Id>
+    </SoftDependencyIds>
 
     <Platforms>Windows</Platforms>
 
-    <Commit>c6bc836ce1e4bf20894c73d192b33693274c2dfe</Commit>
+    <Commit>67546f86d2fca95284ca5ac82035514bb1235522</Commit>
 
 </PluginData>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
 
     <Id>B6469FEE-83BF-44A9-93F9-B4A252527C35</Id>
@@ -33,6 +33,6 @@ Optional Anomaly Shader Framework supplies object motion. Rich HUD is supported.
 
     <Platforms>Windows</Platforms>
 
-    <Commit>eada5cbf453dd77e8b0169f43c3a5b18803a1f78</Commit>
+    <Commit>7de5b930f5c230fde3b41f95dcccdcd88ddf2a27</Commit>
 
 </PluginData>

--- a/Plugins/SpaceEngineersDLSS.xml
+++ b/Plugins/SpaceEngineersDLSS.xml
@@ -1,32 +1,29 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
 
     <Id>B6469FEE-83BF-44A9-93F9-B4A252527C35</Id>
     <RepoId>PhoenixTheSage/SE-DLSS</RepoId>
-    <FriendlyName>Zeridian's DLSS 4.5</FriendlyName>
+    <FriendlyName>NVIDIA DLSS</FriendlyName>
     <Author>PhoenixTheSage</Author>
-    <Tooltip>Enables DLSS 4.5 in Space Engineers</Tooltip>
+    <Tooltip>Enables NVIDIA DLSS Super Resolution and DLAA in Space Engineers</Tooltip>
     <Description>
-Adds NVIDIA DLSS &amp; DLAA 4.5 to Space Engineers. 
+Adds NVIDIA DLSS Super Resolution and DLAA. Windows, NVIDIA RTX required. Defaults off.
 
-Requires NVIDA DLSS-capable GPU.
-Built-in support for Rich HUD Framework.
-Built-in support for Anomaly Shader Framework.
+Loads the NVIDIA driver's private _nvngx.dll (System32, NGXCore, or DriverStore) through an OleAut32 trampoline. A native access violation during init cannot be caught from .NET Framework and will close the game. Other failures fail closed.
 
-Anomaly is highly recommended as it provides real motion vectors that remove ghosting.
+Do not enable with HdrRender, SMAA, or SmoothFrames (tone-map, copy-to-RT, billboard, and camera-jitter overlap). Safer paths: HdrRender - use one or the other until an AfterUpscale/HDR-evaluate hook exists; SMAA - use DLSS or SMAA as the AA, not both; SmoothFrames - disable camera interpolation while DLSS is on.
+
+Optional Anomaly Shader Framework supplies object motion. Rich HUD is supported.
     </Description>
 
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
-        <Directory>Assets</Directory>
     </SourceDirectories>
 
-    <!-- NVIDIA DLSS redistributable. Placement=Bin copies it next to plugin.dll.
-         Path is in-repo; -->
-    <!-- <Asset Name="NvngxDlss"
-           Path="Assets/nvngx_dlss.dll"
-           Placement="Bin" /> -->
-    <AssetFolder>Assets</AssetFolder>
+    <Asset Name="NvngxDlss"
+           Url="https://github.com/PhoenixTheSage/SE-DLSS/releases/download/nvngx-dlss-310.7.0/nvngx_dlss.dll"
+           Sha256="be6e434a94ca32499515eb62ca0e6c274526055d568d0426e4c652dcdfb6ee6e"
+           Placement="Bin" />
 
     <!-- Anomaly is optional and discovered at runtime. Camera motion vectors
          remain the fallback when it is not enabled. -->
@@ -36,6 +33,6 @@ Anomaly is highly recommended as it provides real motion vectors that remove gho
 
     <Platforms>Windows</Platforms>
 
-    <Commit>67546f86d2fca95284ca5ac82035514bb1235522</Commit>
+    <Commit>eada5cbf453dd77e8b0169f43c3a5b18803a1f78</Commit>
 
 </PluginData>


### PR DESCRIPTION
Adds NVIDIA DLSS & DLAA 4.5 to Space Engineers. Requires NVIDA DLSS-capable GPU. Has built-in support for Rich HUD Framework.

Source: https://github.com/PhoenixTheSage/SE-DLSS