### PR TITLE
Add Unified Storage

### DIFF
--- a/Plugins/UnifiedStorage.xml
+++ b/Plugins/UnifiedStorage.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<PluginData xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="GitHubPlugin">
+    <Id>4BD38E0B-20BC-4797-A011-44B59E928DA4</Id>
+    <RepoId>OwendB1/se-unified-storage</RepoId>
+    <FriendlyName>Unified Storage</FriendlyName>
+    <Author>Owen de Bree</Author>
+    <Tooltip>One projected ship-wide inventory with definition-driven distribution and a vanilla UI fallback.</Tooltip>
+    <Description>Replaces the grid-side terminal inventory with a unified view while keeping every item in its real container. Includes configurable inventory groups, vanilla and modded inventory support, placement policies, refinery ore priorities, component production targets, loadouts, and transfers between distinct mechanical ship groups when conveyors permit them. Works with unmodified servers; no programmable block or server companion is required. The Unified toggle restores the vanilla inventory UI. An optional Magnetar companion adds shared ship settings.</Description>
+    <SourceDirectories>
+        <Directory>ClientPlugin</Directory>
+        <Directory>Shared</Directory>
+    </SourceDirectories>
+    <Commit>546f5cd5d215100d82c1e4c8ef335760fbea8982</Commit>
+</PluginData>

--- a/Plugins/UnifiedStorage.xml
+++ b/Plugins/UnifiedStorage.xml
@@ -5,10 +5,11 @@
     <FriendlyName>Unified Storage</FriendlyName>
     <Author>Owen de Bree</Author>
     <Tooltip>One projected ship-wide inventory with definition-driven distribution and a vanilla UI fallback.</Tooltip>
-    <Description>Replaces the grid-side terminal inventory with a unified view while keeping every item in its real container. Includes configurable inventory groups, vanilla and modded inventory support, placement policies, refinery ore priorities, component production targets, loadouts, and transfers between distinct mechanical ship groups when conveyors permit them. Works with unmodified servers; no programmable block or server companion is required. The Unified toggle restores the vanilla inventory UI. An optional Magnetar companion adds shared ship settings.</Description>
+    <Description>Replaces the grid-side terminal inventory with a unified view while keeping every item in its real container. Includes configurable inventory groups, vanilla and modded inventory support, placement policies, refinery ore priorities, crafting targets, loadouts, and transfers between distinct mechanical ship groups when conveyors permit them. Works with unmodified servers; no programmable block or server companion is required. The Unified toggle restores the vanilla inventory UI. An optional Magnetar companion adds shared ship settings. Original idea and UI testing by SpaceGT: https://github.com/SpaceGT/</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
         <Directory>Shared</Directory>
+        <Directory>Runtime</Directory>
     </SourceDirectories>
-    <Commit>546f5cd5d215100d82c1e4c8ef335760fbea8982</Commit>
+    <Commit>747a6dd372ce1fa89bfe6113f5f6cf7c63ad4b4f</Commit>
 </PluginData>


### PR DESCRIPTION
## Unified Storage

Registers [OwendB1/se-unified-storage](https://github.com/OwendB1/se-unified-storage) at source commit `546f5cd5d215100d82c1e4c8ef335760fbea8982`.

The client plugin replaces the grid-side terminal inventory with aggregate views while items remain in their real inventories. It supports configurable inventory groups, definition-derived modded inventory handling, placement/rebalance policies, refinery priorities, component targets, generic loadouts, and transfers between distinct mechanical ship groups when vanilla conveyor rules permit them. The Unified toggle restores the vanilla UI.

Works against unmodified servers: no programmable block, world mod, or server companion is required. An optional Magnetar companion currently adds shared settings only, using secure vanilla mod messages; it does not provide authoritative transfers or unattended automation.

## Manifest

- Preserves the existing GUID and uses `RepoId` as in the current registry sample.
- Compiles only `ClientPlugin` and `Shared`; excludes tests and the server entry point.
- No bundled binaries, external assets, or additional package dependencies. Harmony and Cecil are loader-provided dependencies.
- Source pin is the public implementation commit. The subsequent plugin-repository commit only finalizes the XML descriptors.

## Verification

- Registry `python3 test.py Plugins`: all files validated.
- Client and server Release MSBuilds with `LOCAL_BUILD` absent: pass, zero warnings/errors.
- Existing distribution core checks: pass.
- Prior client in-game verification and remaining limitations: [UI_E2E_VERIFICATION.md](https://github.com/OwendB1/se-unified-storage/blob/546f5cd5d215100d82c1e4c8ef335760fbea8982/Docs/UI_E2E_VERIFICATION.md).
- The newest shared-profile UI and dedicated-server multiplayer integration still need live acceptance testing: [companion status](https://github.com/OwendB1/se-unified-storage/blob/546f5cd5d215100d82c1e4c8ef335760fbea8982/Docs/SERVER_COMPANION_IMPLEMENTATION.md). MSBuild validation is not a claim of a fresh loader Init/live multiplayer pass for this exact pin.
