### PR TITLE
chore: update LinuxCompat to 1.0.18

### DIFF
--- a/Plugins/LinuxCompat.xml
+++ b/Plugins/LinuxCompat.xml
@@ -35,6 +35,6 @@
     <Runtimes>CoreCLR</Runtimes>
     <Platforms>Linux</Platforms>
     <Hidden>true</Hidden>
-    <Commit>611f6ae577c4b304a7946a039ed6aaca9da5f1c6</Commit>
+    <Commit>11a702bc2977523b8ed12ce9a1e97c4052b4e8dd</Commit>
 
 </PluginData>


### PR DESCRIPTION
Update LinuxCompat’s source pin to 1.0.18, including the native Wayland Steam overlay input fix and startup diagnostics for missing native dependencies.

Depends on https://github.com/CometWorks/linux-compat/pull/41. This draft pins the version PR’s source commit; after that PR merges, refresh the pin to the final merge commit before publishing this update.

The overlay can render on Wayland while Shift+Tab remains unresponsive. The plugin now forwards input through Steam’s Xlib hooks without changing the game’s native Wayland window, X11 support, or Pulsar launch arguments. The user confirmed the shortcut works in Space Engineers.

This updates only the `linux-compat` entry used by unified Pulsar. Existing native-asset versions/checksums and the legacy `se-linux-compat` entry remain unchanged.

Validation: `python3 test.py Plugins/` and `git diff --check` passed. LinuxCompat client/server Release builds passed, and the overlay fix has standalone, native SDL/Vulkan/virtual-controller, and manual in-game validation recorded in https://github.com/CometWorks/linux-compat/pull/40.

Pulsar 2.4.0 reads PluginHub source metadata directly and rebuilds when the pinned commit changes. No Pulsar release or manual Plugin List Updater workflow run is needed for this plugin update. Local/dev-folder overrides take precedence and must be removed or updated separately to receive the upstream plugin.
