### PR TITLE
Update Unified Storage: fix inventory activation

### DIFF
--- a/Plugins/UnifiedStorage.xml
+++ b/Plugins/UnifiedStorage.xml
@@ -11,5 +11,5 @@
         <Directory>Shared</Directory>
         <Directory>Runtime</Directory>
     </SourceDirectories>
-    <Commit>747a6dd372ce1fa89bfe6113f5f6cf7c63ad4b4f</Commit>
+    <Commit>f79f801bc62ac16b5ec10b8f082d733895589fde</Commit>
 </PluginData>


### PR DESCRIPTION
Bump Unified Storage from `747a6dd372ce1fa89bfe6113f5f6cf7c63ad4b4f` to `f79f801bc62ac16b5ec10b8f082d733895589fde`.

The capacity label enabled automatic ellipsis with null initial text, causing a NullReferenceException and fallback to vanilla inventory. Initialize it with an empty string before assigning the live space totals.

Verification:
- Release build passed.
- Pulsar dev-folder source compilation and loading passed.
- Tested the supplied Red Ship repro world: unified activation succeeds with Hide empty on and off, including after both unified columns were disabled.
- Tested with Can Use All Terminals enabled and disabled.
- Registry validator: All files validated.

Client UI fix only; no server companion changes.