### PR TITLE
Update Unified Storage: inventory UX and BOM import

### DIFF
--- a/Plugins/UnifiedStorage.xml
+++ b/Plugins/UnifiedStorage.xml
@@ -11,5 +11,5 @@
         <Directory>Shared</Directory>
         <Directory>Runtime</Directory>
     </SourceDirectories>
-    <Commit>f79f801bc62ac16b5ec10b8f082d733895589fde</Commit>
+    <Commit>6ada181bb9b542ffe819ed0c6616e4f7a02fe9fc</Commit>
 </PluginData>


### PR DESCRIPTION
Pins Unified Storage to 6ada181bb9b542ffe819ed0c6616e4f7a02fe9fc.

Changes:
- Fix non-unified inventory overlap after rebalance and empty-search control clipping.
- Restore modifier transfers, amount dialogs, Enter/controller input paths, and native inventory action buttons.
- Add previewed loadout BOM import compatible with MGP Copy BoM and finite Isy Special-container targets.
- Show delayed, cancellable progress for local refinery/assembler Drain jobs; stop remaining local drain work on terminal close.

Verification:
- Client Release build, core tests, whitespace checks and PluginHub XML validation passed.
- Pulsar devfolder live checks on a local reproduction world at 3440x1440 covered exact 10/100/1000 transfers, right-drag amount 23, double-click, Enter, Deposit All, rebalance panel bounds, fallback toggles, and BOM clipboard/validation/persistence.
- Latest Drain progress wiring passed build/tests but still needs an in-game long-job retest. Controller hardware, completed Build Planner production/withdrawal, and companion profile exchange were not certified in this pass.
- Existing MSBuild deployment warning points to the obsolete .config/Pulsar path; live testing used the configured devfolder under Games/Pulsar.

Only the client hub pin changes; no companion protocol or server implementation changes.

Source diff: https://github.com/OwendB1/se-unified-storage/compare/f79f801bc62ac16b5ec10b8f082d733895589fde...6ada181bb9b542ffe819ed0c6616e4f7a02fe9fc