### PR TITLE
Update Unified Storage: Ctrl-drag fix, remove BOM import

### DIFF
--- a/Plugins/UnifiedStorage.xml
+++ b/Plugins/UnifiedStorage.xml
@@ -11,5 +11,5 @@
         <Directory>Shared</Directory>
         <Directory>Runtime</Directory>
     </SourceDirectories>
-    <Commit>6ada181bb9b542ffe819ed0c6616e4f7a02fe9fc</Commit>
+    <Commit>da095983475a0979f9735e79c4af2ee463922f50</Commit>
 </PluginData>


### PR DESCRIPTION
Pins Unified Storage to da095983475a0979f9735e79c4af2ee463922f50.

Changes:
- Ctrl-drag opens the transfer amount dialog; Ctrl-click still transfers ten on release, without an extra transfer before dragging. Ctrl held when dropping also requests an amount. Shift and Ctrl+Shift are unchanged.
- Remove the recently added BOM importer, UI button, parser, tests and documentation. Existing loadout rules remain supported and are not deleted.

Verification:
- Client Release build, core tests, whitespace checks and PluginHub XML validation passed.
- New Ctrl-drag behavior still requires an in-game retest; earlier modifier-click live evidence predates this fix.
- Existing build warning concerns the obsolete .config/Pulsar deployment path; the configured devfolder is under Games/Pulsar.

No server implementation or companion protocol changes.

Source diff: https://github.com/OwendB1/se-unified-storage/compare/6ada181bb9b542ffe819ed0c6616e4f7a02fe9fc...da095983475a0979f9735e79c4af2ee463922f50