### PR TITLE
Update Mirror.xml

### DIFF
--- a/Plugins/Mirror.xml
+++ b/Plugins/Mirror.xml
@@ -3,7 +3,7 @@
     <Id>589B0A8A-DB20-4CE3-8D6A-6B6E5FF03F04</Id>
     
     <RepoId>Voxar/SE-Mirror-Plugin</RepoId>
-    <Commit>765eead36bacd5067c9c170c0135a6d1893f675f</Commit>
+    <Commit>138634818e71f5a8a3762257e46f7dec1aabe3cc</Commit>
 
     <Author>Voxar</Author>
     <FriendlyName>Mirror Mod Renderer</FriendlyName>


### PR DESCRIPTION
- Answers the mod's "Remote Camera" list: which cameras a screen's grid can reach over the antenna network, with the same reach and access rules as the game's own camera view list.
- Fix: camera panels look out from the lens; a hidden camera can no longer see through a wall.

Needs an updated Mirror mod as well for the remote camera option to appear. I'll release that after this. 