### PR TITLE
Update plugin: Ore to Auto Gps (v1.4.2)

### DIFF
--- a/Plugins/OreToAutoGps.xml
+++ b/Plugins/OreToAutoGps.xml
@@ -22,5 +22,5 @@ Report bugs via GitHub issues.</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
-    <Commit>87e8d1f95bf3f0da5d8dc6eee6f5263a7c6233d25</Commit>
+    <Commit>f46e816dec0ea87cfc675fb784a51b37c6a71565</Commit>
 </PluginData>

--- a/Plugins/OreToAutoGps.xml
+++ b/Plugins/OreToAutoGps.xml
@@ -22,5 +22,5 @@ Report bugs via GitHub issues.</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
-    <Commit>600d9653a27e537948773c81452ca19b6ef02412</Commit>
+    <Commit>87e8d1f95bf3f0da5d8dc6eee6f5263a7c6233d25</Commit>
 </PluginData>

--- a/Plugins/OreToAutoGps.xml
+++ b/Plugins/OreToAutoGps.xml
@@ -4,22 +4,23 @@
     <RepoId>dawidmachon/se-ore-to-auto-gps</RepoId>
     <FriendlyName>Ore to Auto Gps</FriendlyName>
     <Author>dawidmachon</Author>
-    <Tooltip>Legit: automatically mark ore your ore detector detects, with an approximate size measured in the background.</Tooltip>
-    <Description>Ore to Auto Gps automatically turns ore your ore detector detects into GPS waypoints - no keybind needed. It is legit: it ONLY ever marks ore the detector has already found; it never reveals ore you have not detected.
+    <Tooltip>Mark ore your ore detector detects as GPS waypoints - but only when you press your mark key. Approximate, vanilla-level size info.</Tooltip>
+    <Description>Ore to Auto Gps turns ore your ore detector has already detected into GPS waypoints - created only when you press your mark key (default Alt+L, rebindable in the plugin settings). Nothing is ever marked automatically, so ore cannot be marked while AFK. Each keypress creates at most a configurable number of NEW markers (default 5, max 5; 0 = no limit) - the most recent deposits; updating markers that already exist is not limited. It is legit: it ONLY ever marks ore the detector has already found; it never reveals ore you have not detected.
 
-To give each waypoint an approximate size and proper center, it measures the already-detected deposits with a background voxel read (anything the detector did not find is discarded). The sizing scan auto-expands to your ore detector's maximum range, so whatever tier of detector you use gets covered.
+To give each waypoint an approximate size and proper center, it measures the already-detected deposits with a background voxel read (anything the detector did not find is discarded). Size info stays at vanilla's information level: rough estimates computed from a BASELINE yield per ore (all ice is sized as regular ice, for example), because the ore detector does not expose which voxel variant (dense ice vs ice) a deposit is.
 
 Features:
-- Fully automatic - markers appear as your detector scans (works while remote-controlling drones, since the drone's detector does the detecting).
+- Player-interaction gate - press your mark key (default Alt+L, rebindable) to mark deposits detected since the last press; no keypress, no markers. Bounded per press: at most N new markers (default 5, max 5; 0 = no limit), the most recent ones - updates of existing markers are not limited.
 - Connected-component grouping: one deposit = one marker at its true center with the real total size, no matter how wide it is.
-- Size bands (Trace/Small/Medium/Large/Huge, Huge >= 5,000,000 kg of ore) plus the potential yield in kg: ore kg and ingot kg @100% (default refinery, no yield upgrades).
+- Size tier in the name (&lt;mineral&gt; &lt;A|P&gt; &lt;tier&gt; &lt;kg&gt;, e.g. "Ore - Gold A Titanic 22.5M"; A=asteroid, P=planet; tiers Atom/Compact/Expand/Giant/Huge/Immense/Mammoth/Titanic) plus an approximate yield in kg using the baseline yield per ore (variant-agnostic, like the detector's own information). Optional display calibration multiplier (default 1.0) scales the shown kg/tier to servers with server-side harvest multipliers - the underlying estimate stays vanilla-baseline.
 - Field markers: scattered tiny deposits within a radius share one marker to avoid clutter.
 - Per-ore toggles, distinct color per ore, smart cross-scan de-duplication.
+- Configurable GPS name prefix (default "Ore - ") so all auto-added waypoints group together in the GPS list for bulk manage/delete and GPS grouping plugins.
 - Runs on a background thread (never freezes the game). Works on dedicated servers (client-side).
 
 Report bugs via GitHub issues.</Description>
     <SourceDirectories>
         <Directory>ClientPlugin</Directory>
     </SourceDirectories>
-    <Commit>2203d19ae148716f1ee2ec78b5d235d209e1d230</Commit>
+    <Commit>600d9653a27e537948773c81452ca19b6ef02412</Commit>
 </PluginData>


### PR DESCRIPTION
What changed since the original registration (#158):

- **v1.4.0 — naming & yields:** A/P source tags (asteroid/planet), new size tiers by calibrated kg (Atom/Compact/Expand/Giant/Huge/Immense/Mammoth/Titanic), field markers now carry their kg estimate, display-only yield-calibration multiplier (underlying estimate stays vanilla-baseline), settings-dialog hardening.
- **v1.4.1 — robustness/UX fixes:** failed GPS updates can no longer delete a marker or corrupt field counts; XML metadata escapes angle brackets; minor UX and docs polish.
- **v1.4.2 — robustness fix:** GPS entry stays reachable when AddGps fails (Add/Remove reordered).

Commit pin updated to the v1.4.2 tag (`f46e816dec0ea87cfc675fb784a51b37c6a71565`).
