### PR TITLE
GX Compass: bump <Commit> to 863f502 (fix build against current SE)

### DIFF
--- a/Plugins/GXCompass.xml
+++ b/Plugins/GXCompass.xml
@@ -17,5 +17,5 @@ Configure it in the plugin's settings screen. Purely visual — it never affects
     <Directory>ClientPlugin</Directory>
   </SourceDirectories>
   <Hidden>false</Hidden>
-  <Commit>19df34fac291312816aeaad3553fefd2a8f6348f</Commit>
+ <Commit>863f502a72d09eac461593a714c33c2e9a030d5c</Commit>
 </PluginData>


### PR DESCRIPTION
SE renamed MyGuiScreenOptionsControls to MyGuiScreenOptionsMouseKeyboard, which broke the from-source Pulsar build (CS0246). Commit 863f502 repoints the keybind rebind dialog to the new screen so GXCompass compiles against the current game DLLs.